### PR TITLE
update to compile with zig 0.12 and 0.13

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -1,19 +1,27 @@
-const Builder = @import("std").build.Builder;
+const Build = @import("std").Build;
 const std = @import("std");
 
-pub fn build(b: *Builder) void {
+pub fn build(b: *Build) void {
     const target = b.standardTargetOptions(.{});
-    const mode = std.builtin.Mode.ReleaseFast;
+    const optimize = b.standardOptimizeOption(.{}); // was: std.builtin.Mode.ReleaseFast;
 
-    const exe = b.addExecutable("pbptool", "src/main.zig");
-    exe.setTarget(target);
-    exe.setBuildMode(mode);
-    exe.setOutputDir("../bin/");
-    exe.install();
+    const exe = b.addExecutable(.{
+        .name = "pbptool",
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    b.installArtifact(exe);
+    // b.getInstallStep().dependOn(&b.addInstallArtifact(
+    //     exe,
+    //     .{
+    //         .dest_dir = .{ .override = .{
+    //             .custom = "../bin/",
+    //         } },
+    //     },
+    // ).step);
 
-    const run_cmd = exe.run();
-    run_cmd.step.dependOn(b.getInstallStep());
-
-    const run_step = b.step("run", "Run the app");
-    run_step.dependOn(&run_cmd.step);
+    const run = b.step("run", "Run the application");
+    const run_cmd = b.addRunArtifact(exe);
+    run.dependOn(&run_cmd.step);
 }

--- a/src/analyze.zig
+++ b/src/analyze.zig
@@ -4,69 +4,70 @@ const mem = std.mem;
 const process = std.process;
 const fs = std.fs;
 
-usingnamespace @import("common.zig");
+const common = @import("common.zig");
+const readHeader = common.readHeader;
+const default_file_names = common.default_file_names;
 
 pub fn analyzePBP() !void {
+    //Allocator setup
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
     //Get args
-    var arg_it = process.args();
+    var arg_it = try process.argsWithAllocator(allocator);
 
     // Skip executable
     _ = arg_it.skip();
     // Skip command
     _ = arg_it.skip();
 
-    //Allocator setup
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = &arena.allocator;
-
     //Get our input file - if it doesn't exist - error out
-    var inputName = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: pbptool analyze <input.pbp>\n\n", .{});
+    const inputName = arg_it.next() orelse {
+        std.log.warn("Usage: pbptool analyze <input.pbp>\n\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, inputName, "-h")){
-        std.debug.warn("Usage: pbptool analyze <input.pbp>\n", .{});
+    if (std.mem.eql(u8, inputName, "-h")) {
+        std.log.warn("Usage: pbptool analyze <input.pbp>\n", .{});
         return;
     }
 
     //Open File
-    var inFile = try fs.cwd().openFile(inputName, fs.File.OpenFlags{.read = true});
+    var inFile = try fs.cwd().openFile(inputName, fs.File.OpenFlags{ .mode = .read_only });
     defer inFile.close();
 
     //Get header
-    var header = try readHeader(inFile);
-    var size = try inFile.getEndPos();
+    const header = try readHeader(inFile);
+    const size = try inFile.getEndPos();
 
     //Print entries
-    std.debug.warn("PBP Entry Table: \n",.{});
+    std.log.warn("PBP Entry Table: \n", .{});
 
-    var i : usize = 0;
-    while(i < 8) : (i += 1){
-        var calcSize : usize = 0;
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        var calcSize: usize = 0;
 
-        if(i + 1 == 8){
+        if (i + 1 == 8) {
             calcSize = size - header.offset[7];
-        }else{
+        } else {
             calcSize = header.offset[i + 1] - header.offset[i];
         }
 
-        if(calcSize == 0){
-            std.debug.warn("\t{s}: \tNOT PRESENT\n", .{default_file_names[i]});
-        }else{
-            std.debug.warn("\t{s}: \tOFFSET {} \t SIZE {}\n", .{default_file_names[i], header.offset[i], calcSize});
+        if (calcSize == 0) {
+            std.log.warn("\t{s}: \tNOT PRESENT\n", .{default_file_names[i]});
+        } else {
+            std.log.warn("\t{s}: \tOFFSET {} \t SIZE {}\n", .{ default_file_names[i], header.offset[i], calcSize });
         }
     }
-    std.debug.warn("PBP Entry Table End\n\n", .{});
+    std.log.warn("PBP Entry Table End\n\n", .{});
 
     //Read Version
     try inFile.seekTo(4);
-    var ver_maj = inFile.reader().readIntNative(u16);
-    var ver_min = inFile.reader().readIntNative(u16);
+    const ver_maj = inFile.reader().readInt(u16, .little);
+    const ver_min = inFile.reader().readInt(u16, .little);
 
     //Finish Print
-    std.debug.warn("PBP Version: {}.{}\n", .{ver_maj, ver_min});
-    std.debug.warn("Size: {} bytes.\n", .{size});
+    std.log.warn("PBP Version: {}.{}\n", .{ ver_maj, ver_min });
+    std.log.warn("Size: {} bytes.\n", .{size});
 }

--- a/src/analyze.zig
+++ b/src/analyze.zig
@@ -64,8 +64,8 @@ pub fn analyzePBP() !void {
 
     //Read Version
     try inFile.seekTo(4);
-    const ver_maj = inFile.reader().readInt(u16, .little);
-    const ver_min = inFile.reader().readInt(u16, .little);
+    const ver_maj = try inFile.reader().readInt(u16, .little);
+    const ver_min = try inFile.reader().readInt(u16, .little);
 
     //Finish Print
     std.log.warn("PBP Version: {}.{}\n", .{ ver_maj, ver_min });

--- a/src/common.zig
+++ b/src/common.zig
@@ -7,48 +7,48 @@ const fs = std.fs;
 //The standard header structure for a PBP File
 //This includes a 4 byte signature, followed by the 4 byte version number
 //Then ends with an offset table for its component files.
-pub const PbpHeader = struct{
+pub const PbpHeader = struct {
     signature: [4]u8,
     version: [4]u8,
     offset: [8]u32,
 };
 
 //The default file names of the PBP components
-pub var default_file_names : [8][]const u8 =  [8][]const u8{
-   "PARAM.SFO",
-   "ICON0.PNG",
-   "ICON1.PMF",
-   "PIC0.PNG",
-   "PIC1.PNG",
-   "SND0.AT3",
-   "DATA.PSP",
-   "DATA.PSAR"
+pub const default_file_names: [8][]const u8 = [8][]const u8{
+    "PARAM.SFO",
+    "ICON0.PNG",
+    "ICON1.PMF",
+    "PIC0.PNG",
+    "PIC1.PNG",
+    "SND0.AT3",
+    "DATA.PSP",
+    "DATA.PSAR",
 };
 
 //Reads a PBP Header file
 pub fn readHeader(file: fs.File) !PbpHeader {
-    var header : PbpHeader = undefined;
+    var header: PbpHeader = undefined;
 
     var instream = file.reader();
 
     var bytes_read = try instream.read(header.signature[0..]);
-    
-    if(bytes_read != 4 and std.mem.eql(u8, header.signature[1..], "PBP")){
-        std.debug.warn("Could not read the header!", .{});
+
+    if (bytes_read != 4 and std.mem.eql(u8, header.signature[1..], "PBP")) {
+        std.log.warn("Could not read the header!", .{});
         return error.BadHeader;
     }
 
     bytes_read = try instream.read(header.version[0..]);
-    if(bytes_read != 4){
-        std.debug.warn("Could not read the header!", .{});
+    if (bytes_read != 4) {
+        std.log.warn("Could not read the header!", .{});
         return error.BadHeader;
     }
 
-    var i : usize = 0;
-    while(i < 8) : (i += 1){
-        header.offset[i] = try instream.readIntNative(u32);
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        header.offset[i] = try instream.readInt(u32, .little);
     }
 
-    std.debug.warn("Valid Header!\n\n", .{});
+    std.log.warn("Valid Header!\n\n", .{});
     return header;
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -5,42 +5,41 @@ const analyze = @import("analyze.zig");
 const unpack = @import("unpack.zig");
 
 pub fn main() !void {
-    //Get args
-    var arg_it = process.args();
-    // Skip executable
-    _ = arg_it.skip();
-
     //Allocator setup
     var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
     defer arena.deinit();
-    const allocator = &arena.allocator;
+    const allocator = arena.allocator();
 
-    var optionSelected = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: pbptool [pack | unpack | analyze] file <...>\n", .{});
+    //Get args
+    var arg_it = try process.argsWithAllocator(allocator);
+    // Skip executable
+    _ = arg_it.skip();
+
+    const optionSelected = arg_it.next() orelse {
+        std.log.warn("Usage: pbptool [pack | unpack | analyze] file <...>\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, optionSelected, "-h")){
-        std.debug.warn("Usage: pbptool [pack | unpack | analyze] file <...>\n", .{});
+    if (std.mem.eql(u8, optionSelected, "-h")) {
+        std.log.warn("Usage: pbptool [pack | unpack | analyze] file <...>\n", .{});
         return;
     }
-    
-    if(std.mem.eql(u8, optionSelected, "-v")){
-        std.debug.warn("zPBPTool Utility made by zPSP-Dev!\n\n", .{});
-        std.debug.warn("Version 1.0\n", .{});
+
+    if (std.mem.eql(u8, optionSelected, "-v")) {
+        std.log.warn("zPBPTool Utility made by zPSP-Dev!\n\n", .{});
+        std.log.warn("Version 1.0\n", .{});
         return;
     }
 
-    if(std.mem.eql(u8, optionSelected, "pack")){
+    if (std.mem.eql(u8, optionSelected, "pack")) {
         try pack.packPBP();
     }
 
-    if(std.mem.eql(u8, optionSelected, "analyze")){
+    if (std.mem.eql(u8, optionSelected, "analyze")) {
         try analyze.analyzePBP();
     }
 
-    if(std.mem.eql(u8, optionSelected, "unpack")){
+    if (std.mem.eql(u8, optionSelected, "unpack")) {
         try unpack.unpackPBP();
     }
-
 }

--- a/src/pack.zig
+++ b/src/pack.zig
@@ -4,7 +4,8 @@ const mem = std.mem;
 const process = std.process;
 const fs = std.fs;
 
-usingnamespace @import("common.zig");
+const common = @import("common.zig");
+const PbpHeader = common.PbpHeader;
 
 //The PBP Header itself consists of a signature starting with NULL, followed by 'PBP'.
 //It also contains a version (two shorts), which in this case is v0.1
@@ -12,9 +13,9 @@ usingnamespace @import("common.zig");
 //If something has 0 length - it is not included.
 //By default we must offset by 40 (the header length).
 var header = PbpHeader{
-    .signature = .{0x00, 'P', 'B', 'P'},
-    .version = .{0x00, 0x00, 0x01, 0x00},
-    .offset = .{40, 0, 0, 0, 0, 0, 0, 0}
+    .signature = .{ 0x00, 'P', 'B', 'P' },
+    .version = .{ 0x00, 0x00, 0x01, 0x00 },
+    .offset = .{ 40, 0, 0, 0, 0, 0, 0, 0 },
 };
 
 //This function write the PBP header to a file
@@ -24,125 +25,123 @@ fn writeHeader(file: fs.File) !void {
     var outputStream = file.writer();
 
     //Write the signature
-    var x : usize = 0;
-    while(x < 4) : (x += 1) {
+    var x: usize = 0;
+    while (x < 4) : (x += 1) {
         try outputStream.writeByte(header.signature[x]);
     }
-    
+
     //Write the version
     x = 0;
-    while(x < 4) : (x += 1) {
+    while (x < 4) : (x += 1) {
         try outputStream.writeByte(header.version[x]);
     }
 
     //Write the offset table
     x = 0;
-    while(x < 8) : (x += 1) {
-        try outputStream.writeIntNative(u32, header.offset[x]);
+    while (x < 8) : (x += 1) {
+        try outputStream.writeInt(u32, header.offset[x], .little);
     }
 }
 
 pub fn packPBP() !void {
+    //Allocator setup
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
     //Get args
-    var arg_it = process.args();
+    var arg_it = try process.argsWithAllocator(allocator);
 
     // Skip executable
     _ = arg_it.skip();
     // Skip command
     _ = arg_it.skip();
 
-    //Allocator setup
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = &arena.allocator;
-
     //Get our output file - if it doesn't exist - error out
-    var outputName = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: pbptool pack <output.pbp> <param.sfo> <icon0.png> <icon1.pmf> <pic0.png> <pic1.png> <snd0.at3> <data.psp> <data.psar>\n\n", .{});
+    const outputName = arg_it.next() orelse {
+        std.log.warn("Usage: pbptool pack <output.pbp> <param.sfo> <icon0.png> <icon1.pmf> <pic0.png> <pic1.png> <snd0.at3> <data.psp> <data.psar>\n\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, outputName, "-h")){
-        std.debug.warn("Usage: pbptool pack <output.pbp> <param.sfo> <icon0.png> <icon1.pmf> <pic0.png> <pic1.png> <snd0.at3> <data.psp> <data.psar>\n", .{});
+    if (std.mem.eql(u8, outputName, "-h")) {
+        std.log.warn("Usage: pbptool pack <output.pbp> <param.sfo> <icon0.png> <icon1.pmf> <pic0.png> <pic1.png> <snd0.at3> <data.psp> <data.psar>\n", .{});
         return;
     }
 
     //File Size Array for Offset table generation
-    var filesizes : [8]usize = [_]usize{0} ** 8;
-    var fileNames : [8][]const u8 = undefined;
- 
+    var filesizes: [8]usize = [_]usize{0} ** 8;
+    var fileNames: [8][]const u8 = undefined;
+
     //Read the files from command - get their lengths
-    var i : usize = 0;
-    while(i < 8) : (i += 1){
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
         //Get the command arg
-        const arg = try (arg_it.next(allocator) orelse {
-            std.debug.warn("Usage: pbptool pack <output.pbp> <param.sfo> <icon0.png> <icon1.pmf> <pic0.png> <pic1.png> <snd0.at3> <data.psp> <data.psar>\n\n", .{});
-            
-            std.debug.warn("Found {} arguments instead of 8!\n", .{i});
+        const arg = arg_it.next() orelse {
+            std.log.warn("Usage: pbptool pack <output.pbp> <param.sfo> <icon0.png> <icon1.pmf> <pic0.png> <pic1.png> <snd0.at3> <data.psp> <data.psar>\n\n", .{});
+
+            std.log.warn("Found {} arguments instead of 8!\n", .{i});
             return error.TooFewArgs;
-        });
+        };
 
         fileNames[i] = arg;
 
         //If a file doesn't exist - we skip it.
-        if(std.mem.eql(u8, arg, "NULL")){
+        if (std.mem.eql(u8, arg, "NULL")) {
             continue;
         }
 
         //Open up the file
-        var f = try fs.cwd().openFile(arg, fs.File.OpenFlags{.read = true});
+        var f = try fs.cwd().openFile(arg, fs.File.OpenFlags{ .mode = .read_only });
         defer f.close();
 
         //Read the size - the end position
-        var size : u64 = try f.getEndPos();
-        filesizes[i] = @truncate(u32, size);
+        const size: u64 = try f.getEndPos();
+        filesizes[i] = @as(u32, @truncate(size));
     }
-
 
     //Create the file offset table
-    std.debug.warn("PBP Entry Table: \n", .{});
+    std.log.warn("PBP Entry Table: \n", .{});
     i = 1;
-    while(i < 8) : (i += 1){
+    while (i < 8) : (i += 1) {
         //Sets the offset to the previous generated value plus the size of this element
-        header.offset[i] = @truncate(u32, header.offset[i - 1] + filesizes[i - 1]);
+        header.offset[i] = @as(u32, @truncate(header.offset[i - 1] + filesizes[i - 1]));
 
-        if(filesizes[i - 1] != 0){
-            std.debug.warn("\tEntry: {s} Added at {} offset.\t\t\t(Size {} bytes)\n", .{fileNames[i - 1], header.offset[i - 1], filesizes[i - 1]});
+        if (filesizes[i - 1] != 0) {
+            std.log.warn("\tEntry: {s} Added at {} offset.\t\t\t(Size {} bytes)\n", .{ fileNames[i - 1], header.offset[i - 1], filesizes[i - 1] });
         }
     }
-    std.debug.warn("PBP Entry Table End\n\n", .{});
+    std.log.warn("PBP Entry Table End\n\n", .{});
 
     //Open File
-    var outputFile = try fs.cwd().createFile(outputName, fs.File.CreateFlags {.truncate = true});
+    var outputFile = try fs.cwd().createFile(outputName, fs.File.CreateFlags{ .truncate = true });
     defer outputFile.close();
 
     //Write the PBP header
     try writeHeader(outputFile);
-    
+
     //Write each file (directly - no formatting) to the PBP after the header
-    std.debug.warn("Writing...\n",.{});
+    std.log.warn("Writing...\n", .{});
 
     i = 0;
-    while(i < 8) : (i += 1){
+    while (i < 8) : (i += 1) {
         //Skip if non-existent
-        if(std.mem.eql(u8, fileNames[i], "NULL")){
+        if (std.mem.eql(u8, fileNames[i], "NULL")) {
             continue;
         }
 
         //Open File
-        var f = try fs.cwd().openFile(fileNames[i], fs.File.OpenFlags{.read = true});
+        var f = try fs.cwd().openFile(fileNames[i], fs.File.OpenFlags{ .mode = .read_only });
         defer f.close();
-        
+
         //Read fragment to buffer
-        var buf : [std.mem.page_size]u8 = undefined;
+        var buf: [std.mem.page_size]u8 = undefined;
         var bytes_read = try f.read(buf[0..]);
 
         //Read / Write loop
-        while(bytes_read > 0){
+        while (bytes_read > 0) {
             //Write it now
-            var x : usize = 0;
-            while(x < bytes_read) : (x += 1){
+            var x: usize = 0;
+            while (x < bytes_read) : (x += 1) {
                 try outputFile.writer().writeByte(buf[x]);
             }
 
@@ -151,5 +150,5 @@ pub fn packPBP() !void {
         }
     }
 
-    std.debug.warn("Saved to {s}! (Wrote {} bytes)\n",.{outputName, header.offset[7] + filesizes[7]});
+    std.log.warn("Saved to {s}! (Wrote {} bytes)\n", .{ outputName, header.offset[7] + filesizes[7] });
 }

--- a/src/unpack.zig
+++ b/src/unpack.zig
@@ -4,96 +4,97 @@ const mem = std.mem;
 const process = std.process;
 const fs = std.fs;
 
-usingnamespace @import("common.zig");
+const common = @import("common.zig");
+const readHeader = common.readHeader;
+const default_file_names = common.default_file_names;
 
 pub fn unpackPBP() !void {
+    //Allocator setup
+    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
+    defer arena.deinit();
+    const allocator = arena.allocator();
+
     //Get args
-    var arg_it = process.args();
+    var arg_it = try process.argsWithAllocator(allocator);
 
     // Skip executable
     _ = arg_it.skip();
     // Skip command
     _ = arg_it.skip();
 
-    //Allocator setup
-    var arena = std.heap.ArenaAllocator.init(std.heap.page_allocator);
-    defer arena.deinit();
-
-    const allocator = &arena.allocator;
-
     //Get our input file - if it doesn't exist - error out
-    var inputName = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: pbptool unpack <input.pbp> <dir>\n\n", .{});
+    const inputName = arg_it.next() orelse {
+        std.log.warn("Usage: pbptool unpack <input.pbp> <dir>\n\n", .{});
         return;
-    });
+    };
 
-    if(std.mem.eql(u8, inputName, "-h")){
-        std.debug.warn("Usage: pbptool unpack <input.pbp> <dir>\n", .{});
+    if (std.mem.eql(u8, inputName, "-h")) {
+        std.log.warn("Usage: pbptool unpack <input.pbp> <dir>\n", .{});
         return;
     }
 
-    var dirName = try (arg_it.next(allocator) orelse{
-        std.debug.warn("Usage: pbptool unpack <input.pbp> <dir>\n\n", .{});
+    const dirName = arg_it.next() orelse {
+        std.log.warn("Usage: pbptool unpack <input.pbp> <dir>\n\n", .{});
         return;
-    });
+    };
 
     //Read
-    var inFile = try fs.cwd().openFile(inputName, fs.File.OpenFlags{.read = true});
+    var inFile = try fs.cwd().openFile(inputName, fs.File.OpenFlags{ .mode = .read_only });
     defer inFile.close();
 
     //Validate header
-    var header = try readHeader(inFile);
-    var size = try inFile.getEndPos();
+    const header = try readHeader(inFile);
+    const size = try inFile.getEndPos();
 
     //Read each
-    var i : usize = 0;
-    while(i < 8) : (i += 1){
-        var calcSize : usize = 0;
+    var i: usize = 0;
+    while (i < 8) : (i += 1) {
+        var calcSize: usize = 0;
 
-        if(i + 1 == 8){
+        if (i + 1 == 8) {
             calcSize = size - header.offset[7];
-        }else{
+        } else {
             calcSize = header.offset[i + 1] - header.offset[i];
         }
 
         //Make a file!
-        if(calcSize != 0){
-            std.debug.warn("Creating {s} with {} bytes... ", .{default_file_names[i], calcSize});
+        if (calcSize != 0) {
+            std.log.warn("Creating {s} with {} bytes... ", .{ default_file_names[i], calcSize });
 
-            var result = try allocator.alloc(u8, dirName.len+default_file_names[i].len);
+            var result = try allocator.alloc(u8, dirName.len + default_file_names[i].len);
             defer allocator.free(result);
-            mem.copy(u8, result[0..], dirName);
-            mem.copy(u8, result[dirName.len..], default_file_names[i]);
+            mem.copyForwards(u8, result[0..], dirName);
+            mem.copyForwards(u8, result[dirName.len..], default_file_names[i]);
 
             //Open
-            var outputFile = try fs.cwd().createFile(result, fs.File.CreateFlags {.truncate = true});
+            var outputFile = try fs.cwd().createFile(result, fs.File.CreateFlags{ .truncate = true });
             defer outputFile.close();
 
-            var buf : [1]u8 = undefined;
+            var buf: [1]u8 = undefined;
             try inFile.seekTo(header.offset[i]);
 
-            var bytes_read : usize = 0;
-    
+            var bytes_read: usize = 0;
+
             //Read / Write loop
-            while(bytes_read < calcSize){
+            while (bytes_read < calcSize) {
                 bytes_read += try inFile.read(buf[0..]);
 
                 //Write it now
-                var x : usize = 0;
-                while(x < buf.len) : (x += 1){
-                    if(bytes_read < calcSize){
+                var x: usize = 0;
+                while (x < buf.len) : (x += 1) {
+                    if (bytes_read < calcSize) {
                         try outputFile.writer().writeByte(buf[x]);
-                    }else{
+                    } else {
                         break;
                     }
                 }
-    
-                if(bytes_read == calcSize){
+
+                if (bytes_read == calcSize) {
                     break;
                 }
             }
-            
-            std.debug.warn("done.\n", .{});
+
+            std.log.warn("done.\n", .{});
         }
     }
 }


### PR DESCRIPTION
Updated the PBP tool to compile under Zig version both `0.12.0-dev.3653+e45bdc6bd` and `0.13.0-dev.267+793f820b3`.

Any format/whitespace changes are a result of saving with `zig fmt`

Unable to currently really know if the tool is working correctly for one reason:
- the main build in Zig-PSP repo currently errors out when trying to do a freestanding build (Internal Zig error with LLVM emit)